### PR TITLE
bugfixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,8 @@ jobs:
         run: make trip
       - name: Run valgrind
         run: make valgrind
+      - name: Run garbage collection stress
+        run: |
+          sudo make clean
+          make debug-stress-gc
+          make tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,5 @@ jobs:
         run:  make integration
       - name: Run trip tests
         run: make trip
+      - name: Run valgrind
+        run: make valgrind

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/**/*
 
 !build/Dockerfile
+!build/Dockerfile.valgrind
 !build/c.make
 
 **/*/.DS_Store

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ test-leaks:
 # Run valgrind against the integration tests.
 test-valgrind:
 	@ $(MAKE) debug
-	@ valgrind --leak-check=full --track-origins=yes -s build/nat test/integration/__index__
+	@ valgrind --leak-check=full --track-origins=yes --error-exitcode=1 -s build/nat test/integration/__index__
 
 # Run valgrind against the integration tests in a container.
 valgrind:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BUILD_DIR := build
 CURRENT_DIR := $(shell pwd)
 BIN := $(HOME)/bin
+HAS_LEAKS := false
 
 default: clean dev
 
@@ -8,43 +9,47 @@ default: clean dev
 clean:
 	@ rm -rf $(BUILD_DIR)/release
 	@ rm -rf $(BUILD_DIR)/debug
-	@ rm $(BUILD_DIR)/nat $(BIN)/nat
+	@ rm -f $(BUILD_DIR)/nat $(BIN)/nat
 
 # Compile the interpreter.
 nat:
 	@ $(MAKE) -f $(BUILD_DIR)/c.make NAME=nat MODE=release SOURCE_DIR=src
 
-# Compile the interpreter in debug mode.
-nat-debug:
-	@ $(MAKE) -f $(BUILD_DIR)/c.make NAME=nat MODE=debug SOURCE_DIR=src
-
 # Compile and symlink to local bin.
 dev:
 	@ $(MAKE) -f $(BUILD_DIR)/c.make NAME=nat MODE=release SOURCE_DIR=src
-	@ ln -s $(CURRENT_DIR)/$(BUILD_DIR)/nat $(BIN)/nat
+	@ ln -s $(BUILD_DIR)/nat $(BIN)/nat
 
-# Compile the interpreter in debug mode and symlink to local bin.
+# Compile the interpreter in debug mode.
 debug:
 	@ $(MAKE) -f $(BUILD_DIR)/c.make NAME=nat MODE=debug SOURCE_DIR=src
-	@ ln -s $(CURRENT_DIR)/$(BUILD_DIR)/nat $(BIN)/nat
+
+# Compile the interpreter with instruction and stack tracing enabled.
+debug-trace:
+	@ $(MAKE) -f $(BUILD_DIR)/c.make NAME=nat MODE=debug-trace SOURCE_DIR=src
 
 # Compile the interpreter with a manic garbage collector.
-debug-gc:
-	@ $(MAKE) -f $(BUILD_DIR)/c.make NAME=nat MODE=debug-gc SOURCE_DIR=src
-	@ ln -s $(CURRENT_DIR)/$(BUILD_DIR)/nat $(BIN)/nat
+debug-stress-gc:
+	@ $(MAKE) -f $(BUILD_DIR)/c.make NAME=nat MODE=debug-stress-gc SOURCE_DIR=src
 
-# Run all the tests.
+# Compile the interpreter
+debug-log-gc:
+	@ $(MAKE) -f $(BUILD_DIR)/c.make NAME=nat MODE=debug-log-gc SOURCE_DIR=src
+
 integration:
-	@ $(CURRENT_DIR)/$(BUILD_DIR)/nat test/integration/__index__ && echo "ok"
+	@ $(BUILD_DIR)/nat test/integration/__index__ && echo "ok"
 
-# Run all the tests.
 trip:
-	@ $(CURRENT_DIR)/$(BUILD_DIR)/nat test/trip/__index__ && echo "ok"
+	@ $(BUILD_DIR)/nat test/trip/__index__ && echo "ok"
 
-# Run all the tests.
 tests:
-	@ $(CURRENT_DIR)/$(BUILD_DIR)/nat test/integration/__index__
-	@ $(CURRENT_DIR)/$(BUILD_DIR)/nat test/trip/__index__
+	@ $(BUILD_DIR)/nat test/integration/__index__
+	@ $(BUILD_DIR)/nat test/trip/__index__
 
+# Compile with debugging enabled, sign the binary, and create a symbol map
+# before calling leaks.
 test-leaks:
-	@ leaks --atExit -- $(CURRENT_DIR)/$(BUILD_DIR)/nat test/integration/__index__ && echo "ok"
+	@ $(MAKE) -f $(BUILD_DIR)/c.make NAME=nat MODE=debug SOURCE_DIR=src
+	@ codesign -s - --entitlements $(BUILD_DIR)/nat.entitlements -f build/nat
+	@ dsymutil build/nat
+	@ MallocStackLogging=1 leaks --atExit -- $(BUILD_DIR)/nat test/integration/__index__

--- a/build/Dockerfile.valgrind
+++ b/build/Dockerfile.valgrind
@@ -1,0 +1,2 @@
+FROM alpine:latest
+RUN apk add g++ valgrind make

--- a/build/c.make
+++ b/build/c.make
@@ -18,10 +18,16 @@ CFLAGS += -Wall -Wextra -Werror -Wno-unused-parameter
 
 # Mode configuration.
 ifeq ($(MODE),debug)
+	CFLAGS += -O0 -DDEBUG -g
+	BUILD_DIR := build/debug
+else ifeq ($(MODE),debug-trace)
 	CFLAGS += -O0 -DDEBUG -g -D DEBUG_PRINT_CODE -D DEBUG_TRACE_EXECUTION
 	BUILD_DIR := build/debug
-else ifeq ($(MODE),debug-gc)
-	CFLAGS += -O0 -DDEBUG -g -D DEBUG_STRESS_GC -D DEBUG_LOG_GC
+else ifeq ($(MODE),debug-log-gc)
+	CFLAGS += -O0 -DDEBUG -g -D DEBUG_LOG_GC
+	BUILD_DIR := build/debug
+else ifeq ($(MODE),debug-stress-gc)
+	CFLAGS += -O0 -DDEBUG -g -D DEBUG_STRESS_GC
 	BUILD_DIR := build/debug
 else
 	CFLAGS += -O3 -flto

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -338,7 +338,7 @@ static void initCompiler(Compiler* compiler, FunctionType type, char* name) {
   current = compiler;
   current->function->name = functionName(type, name);
 
-  for (int i = 0; i <= UINT8_COUNT; i++) {
+  for (int i = 0; i < UINT8_COUNT; i++) {
     compiler->locals[i].depth = 0;
     compiler->locals[i].isCaptured = false;
 

--- a/src/compiler.c
+++ b/src/compiler.c
@@ -271,7 +271,8 @@ static void emitReturn() {
 static int getConstant(Value value) {
   Value existing;
 
-  if (isHashable(value) && mapGet(current->constants, value, &existing) &&
+  if (isHashable(value) &&
+      mapGet(&current->function->constants, value, &existing) &&
       IS_NUMBER(existing)) {
     return (uint16_t)AS_NUMBER(existing);
   }
@@ -291,7 +292,7 @@ static uint16_t makeConstant(Value value) {
   }
 
   if (isHashable(value))
-    mapSet(current->constants, value, NUMBER_VAL(constant));
+    mapSet(&current->function->constants, value, NUMBER_VAL(constant));
 
   return (uint16_t)constant;
 }
@@ -334,9 +335,7 @@ static void initCompiler(Compiler* compiler, FunctionType type, char* name) {
   compiler->type = type;
   compiler->localCount = 0;
   compiler->scopeDepth = 0;
-  compiler->constants = NULL;
   compiler->function = newFunction();
-  compiler->constants = newMap();
 
   current = compiler;
   current->function->name = functionName(type, name);
@@ -1589,7 +1588,6 @@ void markCompilerRoots() {
   Compiler* compiler = current;
   while (compiler != NULL) {
     markObject((Obj*)compiler->function);
-    markObject((Obj*)compiler->constants);
     compiler = compiler->enclosing;
   }
 }

--- a/src/core/map.nat
+++ b/src/core/map.nat
@@ -3,7 +3,7 @@ class Map extends Object {
   // Does each key in [this] map to the same value in [other]?
   subMap(other) => {
     for (key in this.keys()) {
-      if (!key in other) return false;
+      if (!(key in other)) return false;
       if (other[key] != this[key]) return false;
     }
     return true;

--- a/src/core/set.nat
+++ b/src/core/set.nat
@@ -31,6 +31,7 @@ class Set extends Object {
   // The compiler calls this method when building a set comprehension.
   add(element) => this.__set__(element, true);
 
+  // The elements of the set are the keys of the underlying map.
   elements() => this.keys();
 
   // Iteration is over elements.

--- a/src/memory.c
+++ b/src/memory.c
@@ -1,5 +1,6 @@
 #include "memory.h"
 
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "compiler.h"

--- a/src/memory.c
+++ b/src/memory.c
@@ -199,6 +199,7 @@ static void markRoots() {
     markObject((Obj*)upvalue);
   }
   markMap(&vm.globals);
+  markMap(&vm.infixes);
   markCompilerRoots();
 
   markObject((Obj*)vm.initString);
@@ -213,8 +214,6 @@ static void markRoots() {
 
   markObject((Obj*)vm.seqClass);
   markObject((Obj*)vm.objClass);
-
-  markObject((Obj*)vm.infixes);
 }
 
 static void traceReferences() {

--- a/src/memory.c
+++ b/src/memory.c
@@ -153,6 +153,7 @@ static void freeObject(Obj* object) {
     case OBJ_FUNCTION: {
       ObjFunction* function = (ObjFunction*)object;
       freeChunk(&function->chunk);
+      freeMap(&function->constants);
       FREE(ObjFunction, object);
       break;
     }

--- a/src/object.c
+++ b/src/object.c
@@ -63,6 +63,7 @@ ObjFunction* newFunction() {
   function->name = NULL;
   function->variadic = false;
   initChunk(&function->chunk);
+  initMap(&function->constants);
   return function;
 }
 
@@ -179,12 +180,6 @@ void initMap(ObjMap* map) {
 void freeMap(ObjMap* map) {
   FREE_ARRAY(MapEntry, map->entries, map->capacity);
   initMap(map);
-}
-
-ObjMap* newMap() {
-  ObjMap* map = ALLOCATE_OBJ(ObjMap, OBJ_MAP);
-  initMap(map);
-  return map;
 }
 
 static MapEntry* mapFindHash(MapEntry* entries, int capacity, Value key,
@@ -344,7 +339,7 @@ void mapRemoveWhite(ObjMap* map) {
 void markMap(ObjMap* map) {
   for (int i = 0; i < map->capacity; i++) {
     MapEntry* entry = &map->entries[i];
-    if (IS_OBJ(entry->key)) markObject(AS_OBJ(entry->key));
+    markValue(entry->key);
     markValue(entry->value);
   }
 }

--- a/src/object.h
+++ b/src/object.h
@@ -49,12 +49,27 @@ struct Obj {
 };
 
 typedef struct {
+  Value key;
+  Value value;
+} MapEntry;
+
+typedef struct {
+  Obj obj;
+  int count;
+  int capacity;
+  MapEntry *entries;
+} ObjMap;
+
+typedef struct {
   Obj obj;
   int arity;
   int upvalueCount;
   bool variadic;
   Chunk chunk;
   ObjString *name;
+  // cache from values to constant indices
+  // in the function's chunk.constants.
+  ObjMap constants;
 } ObjFunction;
 
 typedef bool (*NativeFn)(int argCount, Value *args);
@@ -86,18 +101,6 @@ typedef struct {
   ObjUpvalue **upvalues;
   int upvalueCount;
 } ObjClosure;
-
-typedef struct {
-  Value key;
-  Value value;
-} MapEntry;
-
-typedef struct {
-  Obj obj;
-  int count;
-  int capacity;
-  MapEntry *entries;
-} ObjMap;
 
 typedef struct {
   Obj obj;

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -13,6 +13,13 @@ Scanner initScanner(const char *source) {
   return scanner;
 }
 
+void initToken(Token *token) {
+  token->type = 0;
+  token->start = NULL;
+  token->length = -1;
+  token->line = -1;
+}
+
 void printScanner(Scanner sc) {
   fprintf(stderr, "(scanner current): %s\n", scanner.current);
 }

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -14,7 +14,7 @@ Scanner initScanner(const char *source) {
 }
 
 void initToken(Token *token) {
-  token->type = 0;
+  token->type = -1;
   token->start = NULL;
   token->length = -1;
   token->line = -1;

--- a/src/scanner.h
+++ b/src/scanner.h
@@ -67,6 +67,7 @@ typedef struct {
 
 Scanner initScanner(const char* source);
 Scanner saveScanner();
+void initToken(Token* token);
 void gotoScanner(Scanner scanner);
 void printScanner(Scanner sc);
 void skipWhitespace();

--- a/src/vm.c
+++ b/src/vm.c
@@ -71,6 +71,7 @@ bool initVM() {
 
   initMap(&vm.globals);
   initMap(&vm.strings);
+  initMap(&vm.infixes);
 
   vm.initString = NULL;
   vm.initString = intern("init");
@@ -96,15 +97,13 @@ bool initVM() {
   vm.seqClass = NULL;
   vm.objClass = NULL;
 
-  vm.infixes = NULL;
-  vm.infixes = newMap();
-
   return initializeCore() == INTERPRET_OK;
 }
 
 void freeVM() {
   freeMap(&vm.globals);
   freeMap(&vm.strings);
+  freeMap(&vm.infixes);
 
   vm.initString = NULL;
   vm.callString = NULL;
@@ -114,7 +113,6 @@ void freeVM() {
   vm.subscriptSetString = NULL;
   vm.lengthString = NULL;
   vm.equalString = NULL;
-  vm.infixes = NULL;
 
   freeObjects();
 }
@@ -425,11 +423,13 @@ static InterpretResult loop() {
       }
       case OP_GET_GLOBAL: {
         ObjString* name = READ_STRING();
+
         Value value;
         if (!mapGet(&vm.globals, OBJ_VAL(name), &value)) {
           runtimeError("Undefined variable '%s'.", name->chars);
           return INTERPRET_RUNTIME_ERROR;
         }
+
         vmPush(value);
         break;
       }

--- a/src/vm.c
+++ b/src/vm.c
@@ -708,7 +708,10 @@ InterpretResult execute(int baseFrame) {
         }
         InterpretResult result = interpretFile(AS_STRING(path)->chars);
         if (result != INTERPRET_OK) return result;
-        vmPop();  // the return value of the module's function.
+        // pop the return value of the module's function.
+        // if/when import statements become selective,
+        // it'll probably stick around.
+        vmPop();
         break;
       }
       case OP_THROW: {
@@ -849,7 +852,7 @@ InterpretResult execute(int baseFrame) {
 #undef READ_STRING
 }
 
-InterpretResult interpretUntil(char* path, const char* source, int frame) {
+InterpretResult interpret(char* path, const char* source) {
   ObjFunction* function = compile(source, path);
   if (function == NULL) return INTERPRET_COMPILE_ERROR;
 
@@ -859,9 +862,5 @@ InterpretResult interpretUntil(char* path, const char* source, int frame) {
   vmPush(OBJ_VAL(closure));
   call(closure, 0);
 
-  return execute(frame);
-}
-
-InterpretResult interpret(char* path, const char* source) {
-  return interpretUntil(path, source, vm.frameCount);
+  return execute(vm.frameCount - 1);
 }

--- a/src/vm.h
+++ b/src/vm.h
@@ -22,6 +22,8 @@ typedef struct {
   int frameCount;
   ObjMap strings;
   ObjMap globals;
+  ObjMap infixes;
+
   Obj* objects;
   ObjUpvalue* openUpvalues;
 
@@ -49,7 +51,6 @@ typedef struct {
   ObjClass* seqClass;
   ObjClass* objClass;
 
-  ObjMap* infixes;
 } VM;
 
 typedef enum {

--- a/src/vm.h
+++ b/src/vm.h
@@ -50,7 +50,6 @@ typedef struct {
 
   ObjClass* seqClass;
   ObjClass* objClass;
-
 } VM;
 
 typedef enum {

--- a/test/integration/map.nat
+++ b/test/integration/map.nat
@@ -1,7 +1,7 @@
 
 // declaration and access.
 
-let map = {"a":1, "b": 2};
+let map = {"a": 1, "b": 2};
 
 let a = "a";
 


### PR DESCRIPTION
- fix a lingering issue with the move from 8 bit to 16 bit constant indices wherein 16 bit values are downcast to 8 bit.
- make import execution self contained, instead of allowing it to conclude the rest of computation.
- move constant index cache out of compiler struct so that it's not orphaned.
- set up leaks and valgrind for local and ci environments.
- run the garbage collection stress tests in ci.
- revise a number of native function defs and the `OP_SET_PROPERTY` instruction, where stack vals were popped before object allocations, allowing the garbage collector to deallocate them from under us.